### PR TITLE
Select single department

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
@@ -205,7 +205,7 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
     userOptions &&
     (incident?.assigned_user_email ||
       (configuration.featureFlags.assignSignalToDepartment &&
-        (incident?.routing_departments || categoryDepartments?.length === 1)) ||
+        incident?.routing_departments) ||
       !configuration.featureFlags.assignSignalToDepartment)
 
   const departmentOptions = useMemo(() => {
@@ -218,7 +218,7 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
         value: department.name,
       }))
 
-    return routingDepartments || categoryDepartments?.length === 1
+    return routingDepartments
       ? options
       : options && [{ key: null, value: 'Niet gekoppeld' }, ...options]
   }, [categoryDepartments, routingDepartments])
@@ -407,7 +407,6 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
           <Highlight type="routing_departments">
             <ChangeValue
               component={SelectInput}
-              disabled={categoryDepartments?.length <= 1}
               display="Afdeling"
               options={departmentOptions}
               path="routing_departments"

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
@@ -532,7 +532,7 @@ describe('MetaList', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('should show assigned user with a category with only one department', async () => {
+    it('should not show assigned user with a category with only one department without it being selected', async () => {
       configuration.featureFlags.assignSignalToEmployee = true
       configuration.featureFlags.assignSignalToDepartment = true
       render(
@@ -547,12 +547,11 @@ describe('MetaList', () => {
       await screen.findByTestId('meta-list-date-definition')
 
       expect(
-        screen.getByTestId('meta-list-assigned_user_email-definition')
-      ).toBeInTheDocument()
+        screen.queryByTestId('meta-list-assigned_user_email-definition')
+      ).not.toBeInTheDocument()
       expect(
-        screen.getByTestId('meta-list-assigned_user_email-value')
-      ).toBeInTheDocument()
-      expect(screen.getByText('Niet toegewezen')).toBeInTheDocument()
+        screen.queryByTestId('meta-list-assigned_user_email-value')
+      ).not.toBeInTheDocument()
     })
 
     it('should show assigned user with a selected department', async () => {
@@ -1086,21 +1085,24 @@ describe('MetaList', () => {
         configuration.featureFlags.assignSignalToDepartment = true
       })
 
-      it('should be visible for one category department, but not editable', () => {
+      it('should be visible for one category department', () => {
         render(
           renderWithContext({
             ...incidentFixture,
             category: {
               ...incidentFixture.category,
-              departments: `${departmentAscCode}`,
+              departments: departmentAscCode,
             },
-            routing_departments: [],
+            routing_departments: [
+              {
+                id: departmentAscId,
+                code: departmentAscCode,
+                name: departmentAscName,
+              },
+            ],
           })
         )
 
-        expect(
-          (screen.getByTestId('editRouting_departmentsButton') as any).disabled
-        ).toBe(true)
         expect(screen.queryByText(notFound)).not.toBeInTheDocument()
         expect(screen.queryByText(notLinked)).not.toBeInTheDocument()
         expect(screen.getByText(departmentAscName)).toBeInTheDocument()
@@ -1126,9 +1128,6 @@ describe('MetaList', () => {
           })
         )
 
-        expect(
-          (screen.getByTestId('editRouting_departmentsButton') as any).disabled
-        ).toBe(false)
         expect(screen.queryByText(notFound)).not.toBeInTheDocument()
         expect(screen.queryByText(notLinked)).not.toBeInTheDocument()
         expect(screen.getByText(departmentAscName)).toBeInTheDocument()
@@ -1157,6 +1156,25 @@ describe('MetaList', () => {
         expect(screen.getByText(departmentLabel)).toBeInTheDocument()
         expect(screen.getByText(notFound)).toBeInTheDocument()
         expect(screen.queryByText(notLinked)).not.toBeInTheDocument()
+        expect(screen.queryByText(departmentAscName)).not.toBeInTheDocument()
+        expect(screen.queryByText(departmentAegName)).not.toBeInTheDocument()
+        expect(screen.queryByText(departmentThoName)).not.toBeInTheDocument()
+      })
+
+      it('should indicate when not linked yet, with only one category department', () => {
+        render(
+          renderWithContext({
+            ...incidentFixture,
+            category: {
+              ...incidentFixture.category,
+              departments: departmentAscCode,
+            },
+            routing_departments: [],
+          })
+        )
+
+        expect(screen.queryByText(notFound)).not.toBeInTheDocument()
+        expect(screen.getByText(notLinked)).toBeInTheDocument()
         expect(screen.queryByText(departmentAscName)).not.toBeInTheDocument()
         expect(screen.queryByText(departmentAegName)).not.toBeInTheDocument()
         expect(screen.queryByText(departmentThoName)).not.toBeInTheDocument()

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/index.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/index.ts
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
+
 export { default } from './DetailPanel'

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.test.tsx
@@ -1,3 +1,6 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2021 - 2022 Gemeente Amsterdam */
+
 import { render, screen } from '@testing-library/react'
 import Leaflet from 'leaflet'
 import * as reactRedux from 'react-redux'

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
@@ -1,6 +1,10 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2021 - 2022 Gemeente Amsterdam */
+
 import L from 'leaflet'
 import type { FC } from 'react'
 import { useFetch } from 'hooks'
+import './style.css'
 
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { useSelector } from 'react-redux'
@@ -55,6 +59,7 @@ export const nearbyMarkerIcon = L.icon({
 export const nearbyMarkerSelectedIcon = L.icon({
   iconSize: [40, 40],
   iconUrl: '/assets/images/area-map/icon-pin-red.svg',
+  className: 'selected-nearby-marker',
 })
 
 const formattedDate = (date: string) =>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/style.css
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/style.css
@@ -1,4 +1,6 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2021 - 2022 Gemeente Amsterdam */
 
-export { default } from './NearbyLayer'
+.selected-nearby-marker {
+  z-index: 999 !important;
+}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -215,7 +215,7 @@ const Selector: FC = () => {
           <Layer />
         </WfsLayer>
 
-        <NearbyLayer />
+        <NearbyLayer zoomLevel={MAP_CONTAINER_ZOOM_LEVEL} />
 
         {geolocation && <LocationMarker geolocation={geolocation} />}
 


### PR DESCRIPTION
When a category had only one department. That department was shown on the incident detail page, without it explicitly being routed to that department.
This PR fixes that by showing the incident as not being linked to any department. A department can then be chosen from the dropdown (containing only that one department) after which the incident will be routed to that department explicitly and thus well be shown as such afterward.